### PR TITLE
Vagrant IP config !!! The is a change in the listen location!!!

### DIFF
--- a/API/http.go
+++ b/API/http.go
@@ -25,17 +25,18 @@ const (
 
 func main() {
 	var err error
-	rootpasswd, dbname, listenLocation := "pass", "database", "localhost:8080" // just some values
-	fmt.Scanf("%s", &rootpasswd)
-	fmt.Scanf("%s", &dbname)
+	var dbUser, dbUserPassword, dbName, listenLocation string
+	fmt.Scanf("%s", &dbUser)
+	fmt.Scanf("%s", &dbUserPassword)
+	fmt.Scanf("%s", &dbName)
 	fmt.Scanf("%s", &listenLocation)
-	db, err = sql.Open("mysql", "root:"+rootpasswd+"@/"+dbname)
+	db, err = sql.Open("mysql", dbUser+":"+dbUserPassword+"@/"+dbName)
 
 	if err != nil {
 		log.Printf("encountered error while connecting to database: %v", err)
 	}
 
-	log.Printf("Connected to database '%s', and listening on '%s'...", dbname, listenLocation)
+	log.Printf("Connected to database '%s', and listening on '%s'...", dbName, listenLocation)
 	router := mux.NewRouter()
 
 	// GET Requests for Retrieving

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,5 +2,5 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
   config.vm.provision :shell, path: "setup.sh"
-  config.vm.network "private_network", ip: "192.168.50.4"
+  config.vm.network "public_network"
 end

--- a/setup.sh
+++ b/setup.sh
@@ -46,7 +46,7 @@ mysql -u root --password=root <<< 'drop database if exists TestDB' \
     && echo 'SUCCESS'
 
 # OLD! Command for automatically starting the API
-echo "function old_start_api() { echo -e \"root\nTestDB\n192.168.50.4:2002\" | make run --quiet -C $PROJROOT/API; }" >> /home/vagrant/.bashrc
+echo "function old_start_api() { echo -e \"root\nroot\nTestDB\n192.168.50.4:2002\" | make run --quiet -C $PROJROOT/API; }" >> /home/vagrant/.bashrc
 
 # Command for completely reloading the Database
 echo "function reload_db() { mysql -u root --password=root <<< \"drop database TestDB\" \\
@@ -54,11 +54,18 @@ echo "function reload_db() { mysql -u root --password=root <<< \"drop database T
     && mysql -u root --password=root TestDB < $PROJROOT/database/DDL_statements.sql \\
     && mysql -u root --password=root TestDB < $PROJROOT/database/test_insert_statements.sql; }" >> /home/vagrant/.bashrc
 
+# Command for starting the API, where you specify the arguments:
+# 1] = username for database user
+# 2] = corresponding password for database user
+# 3] = name of the database
+# 4] = location 'ip:port' for api to listen
+echo "function start_api_args() { echo -e \"\$1\n\$2\n\$3\n\$4\" | make run --quiet -C $PROJROOT/API; }" >> /home/vagrant/.bashrc
+
 # Command for retrieving the ip
 echo "function get_ip() { ifconfig eth1 | grep -o 'inet addr:[1-9.]*' | cut -d \":\" -f 2; }" >> /home/vagrant/.bashrc
 
 # Command for starting the api with a specified ip address
-echo "function start_api_ip() { echo -e \"root\nTestDB\n\${1}:2002\" | make run --quiet -C $PROJROOT/API; }" >> /home/vagrant/.bashrc
+echo "function start_api_ip() { echo -e \"root\nroot\nTestDB\n\${1}:2002\" | make run --quiet -C $PROJROOT/API; }" >> /home/vagrant/.bashrc
 
 # New command for automatically starting the API
 echo "function start_api { start_api_ip \$(get_ip); }" >> /home/vagrant/.bashrc

--- a/setup.sh
+++ b/setup.sh
@@ -45,13 +45,23 @@ mysql -u root --password=root <<< 'drop database if exists TestDB' \
     && mysql -u root --password=root TestDB < $PROJROOT/database/test_insert_statements.sql \
     && echo 'SUCCESS'
 
-# Command for automatically starting the API
-echo "alias start_api='echo -e \"root\nTestDB\n192.168.50.4:2002\" | make run --quiet -C $PROJROOT/API'" >> /home/vagrant/.bashrc
+# OLD! Command for automatically starting the API
+echo "function old_start_api() { echo -e \"root\nTestDB\n192.168.50.4:2002\" | make run --quiet -C $PROJROOT/API; }" >> /home/vagrant/.bashrc
 
 # Command for completely reloading the Database
-echo "alias reload_db='mysql -u root --password=root <<< \"drop database TestDB\" \\
+echo "function reload_db() { mysql -u root --password=root <<< \"drop database TestDB\" \\
     && mysql -u root --password=root <<< \"create database TestDB\" \\
     && mysql -u root --password=root TestDB < $PROJROOT/database/DDL_statements.sql \\
-    && mysql -u root --password=root TestDB < $PROJROOT/database/test_insert_statements.sql'" >> /home/vagrant/.bashrc
+    && mysql -u root --password=root TestDB < $PROJROOT/database/test_insert_statements.sql; }" >> /home/vagrant/.bashrc
+
+# Command for retrieving the ip
+echo "function get_ip() { ifconfig eth1 | grep -o 'inet addr:[1-9.]*' | cut -d \":\" -f 2; }" >> /home/vagrant/.bashrc
+
+# Command for starting the api with a specified ip address
+echo "function start_api_ip() { echo -e \"root\nTestDB\n\${1}:2002\" | make run --quiet -C $PROJROOT/API; }" >> /home/vagrant/.bashrc
+
+# New command for automatically starting the API
+echo "function start_api { start_api_ip \$(get_ip); }" >> /home/vagrant/.bashrc
 
 echo -e '------------------\n| Finished Setup |\n------------------'
+


### PR DESCRIPTION
In order to receive api requests from mobile phones (from the same network atm I believe), the IP is now public. It automatically chooses an ip address, which highly likely is different from the previously used ip-address.

You can still use the command `start_api` (which is now a function instead of an alias), which will start the api as before. If successful, you can see the listen location of the api in the output.

Moreover, you can now use some other commands:
* `start_api_ip [ip]`, which starts the api listening from the specified ip
* `start_api_args [database user username] [database user password] [database name] [ip:port]` starts the api with the specified arguments (all are required). The other commands use the default: `username=root`, `password=root`, `dbname=TestDB`, `ip:port=$(get_ip):2002`
* `get_ip` retrieves the ip as specified by vagrant.